### PR TITLE
small change to RedesignDefaultDeck branch.

### DIFF
--- a/src/main/java/com/example/backend/entity/Deck.java
+++ b/src/main/java/com/example/backend/entity/Deck.java
@@ -4,6 +4,7 @@ import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
+import org.hibernate.annotations.GeneratorType;
 
 import javax.persistence.*;
 import java.util.List;
@@ -17,7 +18,7 @@ import java.util.List;
 public class Deck {
 
     @Id
-    @GeneratedValue
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
     private String name;

--- a/src/main/java/com/example/backend/entity/Pao.java
+++ b/src/main/java/com/example/backend/entity/Pao.java
@@ -20,7 +20,7 @@ public class Pao {
     private String action;
     private String object;
 
-    @OneToOne(fetch = FetchType.LAZY, cascade = {CascadeType.ALL})
+    @OneToOne(mappedBy = "pao", fetch = FetchType.LAZY, cascade = {CascadeType.ALL})
     @ToString.Exclude
     private PaoCard paoCard;
 


### PR DESCRIPTION
See individual commits for details.

Jeg har ikke nogen erfaring med at bruge JPA cascade so jeg aner ikke hvordan man bruger dem. MEN!

Det er interessant hvordan man ikke behøver at bruge PaoRepository og PaoCardRepository til manuelt at gemme Pao og PaoCard, men man er stadig nødt til at bruge CardRepository og DeckRepository til manuelt at gemme Card og Deck.

Hvorfor kan DeckRepository ikke gemme det hele, er det fordi at vi ikke vil have kopier af hvert Card i databasen hvis man oprettede et nyt Deck?